### PR TITLE
updated root directory detection

### DIFF
--- a/install.js
+++ b/install.js
@@ -36,6 +36,11 @@ var existsSync = fs.existsSync || path.existsSync;
 // The root of repository.
 //
 var root = path.resolve(__dirname, '../..');
+var exec = require('shelljs').exec;
+var result = exec('git rev-parse --show-toplevel');
+if(result.code === 0){
+  root = path.resolve(result.output.trim());
+}
 
 //
 // The location .git and it's hooks

--- a/package.json
+++ b/package.json
@@ -33,5 +33,8 @@
     "grunt": "^0.4.5",
     "grunt-complexity": "^0.1.6",
     "grunt-bump": "0.0.13"
+  },
+  "dependencies": {
+    "shelljs": "^0.3.0"
   }
 }


### PR DESCRIPTION
For projects where node_modules installed not in subfolders need this feature:
detect real root directory using this command: "git rev-parse --show-toplevel"
