### PR TITLE
Check if branch exists on remote before diffing

### DIFF
--- a/hooks/pre-push.js
+++ b/hooks/pre-push.js
@@ -14,21 +14,29 @@ function haveCommitsToPush(cb) {
     if (stdout.trim().length) {
       branch = stdout.trim();
     }
-    child.exec('git diff --name-only origin/' + branch + '..HEAD', function (err, stdout) {
-      if (err) {
-        console.error(label, 'Failed to check for commits. Cannot run the tests.');
-        console.error(label, err);
-        return process.exit(1);
+    child.exec('git ls-remote --heads origin ' + branch, function (err, stdout) {
+      if (!stdout.trim().length) {
+        console.log('New branch "' + branch + '", pushing...');
+        cb();
+      } else {
+        child.exec('git diff --name-only origin/' + branch + '..HEAD', function (err, stdout) {
+          if (err) {
+            console.error(label, 'Failed to check for commits. Cannot run the tests.');
+            console.error(label, err);
+            return process.exit(1);
+          }
+
+          if (!stdout.trim().length) {
+            console.log('');
+            console.log(label, 'No local commits detected, bailing out.');
+            console.log('');
+            return process.exit(0);
+          }
+          console.log(label, 'Detected files in diff:',  stdout.trim().split('\n').length);
+          cb();
+        });
       }
 
-      if (!stdout.trim().length) {
-        console.log('');
-        console.log(label, 'No local commits detected, bailing out.');
-        console.log('');
-        return process.exit(0);
-      }
-      console.log(label, 'Detected files in diff:',  stdout.trim().split('\n').length);
-      cb();
     });
   });
 }


### PR DESCRIPTION
If the branch is new, it will simply continue. Otherwise, if this is an old branch, it will execute the original pre-git functionality to check the diff.

I created an issue for this, which I guess can be related if you think this is alright