### PR TITLE
Check if the task exited with an error and report an error

### DIFF
--- a/hooks/pre-common.js
+++ b/hooks/pre-common.js
@@ -150,7 +150,7 @@ function runner(root, run) {
       proc.stdout.on('data', process.stdout.write.bind(process.stdout));
       proc.stderr.on('data', process.stderr.write.bind(process.stderr));
       proc.on('close', function onTaskFinished(code) {
-        if (err) {
+        if (code > 0) {
           return next(new Error(task + ' closed with code ' + code), task);
         }
         next(undefined, task);


### PR DESCRIPTION
This just looks like the wrong variable was used.. When changing it to check the exit code, my hooks properly error out and prevent commit/pushes if the task fails.