### PR TITLE
Fix how hooks are run with node --harmony, fixes #63

### DIFF
--- a/bin/commit-msg.js
+++ b/bin/commit-msg.js
@@ -1,5 +1,3 @@
-#!/usr/bin/env node --harmony
-
 'use strict';
 
 const ggit = require('ggit');

--- a/bin/commit-wizard.js
+++ b/bin/commit-wizard.js
@@ -1,5 +1,3 @@
-#!/usr/bin/env node --harmony
-
 console.log('running commit-wizard in folder %s', process.cwd());
 const la = require('lazy-ass');
 const check = require('check-more-types');

--- a/bin/post-commit.js
+++ b/bin/post-commit.js
@@ -1,5 +1,3 @@
-#!/usr/bin/env node --harmony
-
 'use strict';
 
 const label = 'post-commit';

--- a/bin/post-merge.js
+++ b/bin/post-merge.js
@@ -1,5 +1,3 @@
-#!/usr/bin/env node --harmony
-
 'use strict';
 
 const label = 'post-merge';

--- a/bin/pre-commit.js
+++ b/bin/pre-commit.js
@@ -1,5 +1,3 @@
-#!/usr/bin/env node --harmony
-
 'use strict';
 
 const log = require('debug')('pre-git');

--- a/bin/pre-push.js
+++ b/bin/pre-push.js
@@ -1,5 +1,3 @@
-#!/usr/bin/env node --harmony
-
 'use strict';
 
 const log = require('debug')('pre-git');

--- a/hooks/commit-msg
+++ b/hooks/commit-msg
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-./node_modules/.bin/commit-msg "$@"
+/usr/bin/env node --harmony ./node_modules/.bin/commit-msg "$@"

--- a/hooks/post-commit
+++ b/hooks/post-commit
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-./node_modules/.bin/post-commit "$@"
+/usr/bin/env node --harmony ./node_modules/.bin/post-commit "$@"

--- a/hooks/post-merge
+++ b/hooks/post-merge
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-./node_modules/.bin/post-merge "$@"
+/usr/bin/env node --harmony ./node_modules/.bin/post-merge "$@"

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-./node_modules/.bin/pre-commit "$@"
+/usr/bin/env node --harmony ./node_modules/.bin/pre-commit "$@"

--- a/hooks/pre-push
+++ b/hooks/pre-push
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-./node_modules/.bin/pre-push "$@"
+/usr/bin/env node --harmony ./node_modules/.bin/pre-push "$@"


### PR DESCRIPTION
Removed the broken shebang from `bin/*.js`, instead added `/usr/bin/env node --harmony` prefix to commands in `hooks/*`.