### PR TITLE
Be more cautious when rewriting the package.json on install

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ object.
       "grunt build",
       "grunt test"
     ],
+    "post-checkout": "npm install",
     "post-merge": "npm install"
   }
 }
@@ -65,7 +66,7 @@ runs `make post-merge` after pull or merge.
 
 ## Windows
 
-Thanks to [ybiquitous](https://github.com/ybiquitous) for 
+Thanks to [ybiquitous](https://github.com/ybiquitous) for
 [adding support](https://github.com/bahmutov/pre-git/pull/72) for Windows.
 
 * Git Bash (Git for Windows): work fine!

--- a/bin/post-checkout
+++ b/bin/post-checkout
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+
+. "$(dirname "$0")/_pre-git-helpers"
+exec /usr/bin/env node --harmony "$(_readlink_f $0).js" "$@"

--- a/bin/post-checkout.js
+++ b/bin/post-checkout.js
@@ -1,0 +1,10 @@
+#!/usr/bin/env node
+
+'use strict';
+
+const label = 'post-checkout';
+const run = require('pre-git').run;
+const runTask = run.bind(null, label);
+
+runTask()
+  .done();

--- a/hooks/post-checkout
+++ b/hooks/post-checkout
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+./node_modules/.bin/post-merge "$@"

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "commit-msg": "bin/commit-msg",
     "commit-wizard": "bin/commit-wizard",
     "post-commit": "bin/post-commit",
+    "post-checkout": "bin/post-checkout",
     "post-merge": "bin/post-merge",
     "pre-commit": "bin/pre-commit",
     "pre-push": "bin/pre-push"

--- a/src/install.js
+++ b/src/install.js
@@ -87,7 +87,7 @@ if (!existsSync(git) || !fs.lstatSync(git).isDirectory()) {
 console.log('git hooks folder %s', hooks);
 
 var hookScripts = ['commit-msg',
-  'pre-commit', 'pre-push', 'post-commit', 'post-merge'];
+  'pre-commit', 'pre-push', 'post-commit', 'post-checkout', 'post-merge'];
 
 var sourceHooksFolders = join(__dirname, '../hooks');
 


### PR DESCRIPTION
The install script always puts all `config.pre-git` entries as well as `scripts.commit` into the package.json regardless of whether the user already did configure pre-git. This is not nice: If a user wants to leave out some of those config entries, they are inserted again later, e.g. on a later `npm install`. Thus with this PR the entries are only written to package.json if there is no `config.pre-git` key yet in it.