### PR TITLE
Added feature for checking commit message against a given regex

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ object.
 },
 "config": {
   "pre-git": {
+    "msg-pattern": "^(US|DE)\\d+ - .+",
     "commit-msg": "simple",
     "pre-commit": [
       "grunt jshint"
@@ -174,6 +175,20 @@ added empty command list for hook post-commit
 added empty command list for hook post-merge
 saving updated files /Users/kensho/git/test-git-hooks/package.json
 ```
+
+
+```json
+"config": {
+  "pre-git": {
+    "msg-pattern": "whatever-regex-without-delimiters"
+  }
+}
+```
+
+When using msg-pattern, the pre-git will match the commit message against the given pattern,
+if the test fails, then it will stop the execution and will exit the commit, this feature is optional and can be used along with any of the commit wizards, however
+those can be omitted using only the pattern, this is a useful manner of checking a custom message, as some commit may require custom codes as user story prefixes and so on.
+
 
 I am using a small project [test-pre-git](https://github.com/bahmutov/test-pre-git)
 as a test playground for these hooks.

--- a/bin/commit-msg.js
+++ b/bin/commit-msg.js
@@ -8,20 +8,40 @@ const la = require('lazy-ass');
 const check = require('check-more-types');
 const log = require('debug')('pre-git');
 
-const wizard = preGit.wizard();
-if (!wizard) {
-  log('no commit message wizard defined');
-  process.exit(0);
+function checkMessageAgainstPattern(msg, pattern) {
+
+  var regex = new RegExp(pattern);
+  
+  if (!regex.test(msg)) {
+    log('invalid commit message, must match the following pattern: ' + pattern, msg);
+    process.exit(-1);
+  }
+
+  return true;
+
 }
 
-log('found commit message wizard with name', wizard.name);
-
-la(check.fn(wizard.validate),
-  'missing wizard validate method,', Object.keys(wizard));
-la(check.fn(preGit.printError),
-  'missing preGit.printError,', Object.keys(preGit));
-
 function checkMessage(msg) {
+
+  const msgPattern = preGit.customMsgPattern();
+  
+  if (msgPattern) {
+    checkMessageAgainstPattern(msg, msgPattern);
+  }
+
+  const wizard = preGit.wizard();
+  if (!wizard) {
+    log('no commit message wizard defined');
+    process.exit(0);
+  }
+
+  log('found commit message wizard with name', wizard.name);
+
+  la(check.fn(wizard.validate),
+      'missing wizard validate method,', Object.keys(wizard));
+  la(check.fn(preGit.printError),
+      'missing preGit.printError,', Object.keys(preGit));
+
   log('checking commit message:', msg);
   const isValid = wizard.validate(msg);
   if (!isValid) {

--- a/src/pre-git.js
+++ b/src/pre-git.js
@@ -341,13 +341,27 @@ function pickWizard() {
   return wiz;
 }
 
+function customCommitMsgPattern() {
+
+  const pkg = getPackage();
+  const msgPattern = pkg.config && pkg.config['pre-git'] && pkg.config['pre-git']['msg-pattern'];
+
+  if (!msgPattern) {
+    return false;
+  }
+  
+  return msgPattern;
+
+}
+
 module.exports = {
   run: run,
   getTasks: getTasks,
   getProjRoot: getProjRoot,
   printError: printError,
   wizard: pickWizard,
-  hasUntrackedFiles: hasUntrackedFiles
+  hasUntrackedFiles: hasUntrackedFiles,
+  customMsgPattern: customCommitMsgPattern
 };
 
 if (!module.parent) {


### PR DESCRIPTION
This adds a new feature to match the commit message against a given regex configured in the package.json, this can be used with the configured commit wizard as it is non blocker, example: 'msg-pattern': '^(US|DE)\d+ - .+'