### PR TITLE
feat(config): allow custom error message for pattern validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,18 @@ this feature is optional and can be used along with any of the commit wizards, h
 those can be omitted using only the pattern, this is a useful manner of checking
 a custom message, as some commit may require custom codes as user story prefixes and so on.
 
+It is also possible to customize your own msg-pattern-error along with msg-pattern to be more descriptive
+as to why the pattern fails.
+
+```json
+"config": {
+  "pre-git": {
+    "msg-pattern": "whatever-regex-without-delimiters",
+    "msg-pattern-error": "whatever error message that will be thrown when the pattern fails"
+  }
+}
+```
+
 I am using a small project [test-pre-git](https://github.com/bahmutov/test-pre-git)
 as a test playground for these hooks.
 

--- a/bin/commit-msg.js
+++ b/bin/commit-msg.js
@@ -13,6 +13,14 @@ function checkMessageAgainstPattern(msg, pattern) {
   var regex = new RegExp(pattern);
   
   if (!regex.test(msg)) {
+
+    var msgError = preGit.customMsgPatternError();
+
+    if(msgError) {
+      console.error(msgError);
+      console.error('');
+    }
+
     log('invalid commit message, must match the following pattern: ' + pattern, msg);
     process.exit(-1);
   }

--- a/src/pre-git.js
+++ b/src/pre-git.js
@@ -143,6 +143,20 @@ function getConfig() {
   return pkg.config && pkg.config[packageName];
 }
 
+function getConfigProperty(propertyName) {
+  const config = getConfig();
+  if (!config) {
+    return false;
+  }
+  const property = config[propertyName];
+
+  if (!property) {
+    return false;
+  }
+
+  return property;
+}
+
 function hasEnabledOption(config) {
   return 'enabled' in config;
 }
@@ -362,17 +376,12 @@ function pickWizard() {
 }
 
 function customCommitMsgPattern() {
-  const config = getConfig();
-  if (!config) {
-    return false;
-  }
-  const msgPattern = config['msg-pattern'];
+  return getConfigProperty('msg-pattern');
 
-  if (!msgPattern) {
-    return false;
-  }
+}
 
-  return msgPattern;
+function customCommitMsgPatternError() {
+  return getConfigProperty('msg-pattern-error');
 }
 
 module.exports = {
@@ -382,7 +391,8 @@ module.exports = {
   printError: printError,
   wizard: pickWizard,
   hasUntrackedFiles: hasUntrackedFiles,
-  customMsgPattern: customCommitMsgPattern
+  customMsgPattern: customCommitMsgPattern,
+  customMsgPatternError: customCommitMsgPatternError
 };
 
 if (!module.parent) {


### PR DESCRIPTION
### Feature:

This PR adds a `msg-pattern-error` property to the config object to allow custom error logs when the validation performed by `msg-pattern` fails.

### Motivation:
Currently when validation for `msg-pattern` fails, only the `pre-commit` hook logs a message in the console ("pre-commit Nothing the hook needs to do. Bailing out.") since the `checkMessageAgainstPattern` method only calls the debug `log` function when validation fails. 

We are shipping a new major release for our core components which includes `pre-git` and several tools for conventional releases, and I've have encountered several cases of devs not knowing about `pre-git` usage (even though all repos clearly state that it's being used and how the message pattern should be written) and since no clear error message is shown in the console, they just opted into using the `--no-verify` option.

I was torn between just changing the debug `log` method into just `console.error` and adding and additional option to the config, but I thought that maybe this was more helpful since it allows more customization (i.e.: we could direct devs to the documentation regarding our message pattern instead of logging the regex string)

