### PR TITLE
feat(hooks): verifies that `node` is in PATH

### DIFF
--- a/hooks/commit-msg
+++ b/hooks/commit-msg
@@ -7,7 +7,7 @@ if [ ! -d "$DIRECTORY" ]; then
 fi
 
 if [ ! -x "$(command -v node)" ]; then
-  echo "Node binary not found, please ensure it's properly setup"
+  echo "Node binary not found, please ensure it has been properly installed"
   exit -1
 fi
 

--- a/hooks/commit-msg
+++ b/hooks/commit-msg
@@ -6,4 +6,9 @@ if [ ! -d "$DIRECTORY" ]; then
   exit -1
 fi
 
+if [ ! -x "$(command -v node)" ]; then
+  echo "Node binary not found, please ensure it's properly setup"
+  exit -1
+fi
+
 ./node_modules/.bin/commit-msg "$@"

--- a/hooks/post-checkout
+++ b/hooks/post-checkout
@@ -6,7 +6,7 @@ if [ ! -d "$DIRECTORY" ]; then
 fi
 
 if [ ! -x "$(command -v node)" ]; then
-  echo "WARNING: Node binary not found, please ensure it's properly setup"
+  echo "WARNING: Node binary not found, please ensure it has been properly installed"
 fi
 
 if [ -d "$DIRECTORY" ] && [ -x "$(command -v node)" ]; then

--- a/hooks/post-checkout
+++ b/hooks/post-checkout
@@ -5,6 +5,10 @@ if [ ! -d "$DIRECTORY" ]; then
   echo "WARNING: Cannot find node_modules folder, please run 'npm install' first"
 fi
 
-if [ -d "$DIRECTORY" ]; then
+if [ ! -x "$(command -v node)" ]; then
+  echo "WARNING: Node binary not found, please ensure it's properly setup"
+fi
+
+if [ -d "$DIRECTORY" ] && [ -x "$(command -v node)" ]; then
   ./node_modules/.bin/post-checkout "$@"
 fi

--- a/hooks/post-commit
+++ b/hooks/post-commit
@@ -7,7 +7,7 @@ if [ ! -d "$DIRECTORY" ]; then
 fi
 
 if [ ! -x "$(command -v node)" ]; then
-  echo "Node binary not found, please ensure it's properly setup"
+  echo "Node binary not found, please ensure it has been properly installed"
   exit -1
 fi
 

--- a/hooks/post-commit
+++ b/hooks/post-commit
@@ -6,4 +6,9 @@ if [ ! -d "$DIRECTORY" ]; then
   exit -1
 fi
 
+if [ ! -x "$(command -v node)" ]; then
+  echo "Node binary not found, please ensure it's properly setup"
+  exit -1
+fi
+
 ./node_modules/.bin/post-commit "$@"

--- a/hooks/post-merge
+++ b/hooks/post-merge
@@ -7,7 +7,7 @@ if [ ! -d "$DIRECTORY" ]; then
 fi
 
 if [ ! -x "$(command -v node)" ]; then
-  echo "Node binary not found, please ensure it's properly setup"
+  echo "Node binary not found, please ensure it has been properly installed"
   exit -1
 fi
 

--- a/hooks/post-merge
+++ b/hooks/post-merge
@@ -6,4 +6,9 @@ if [ ! -d "$DIRECTORY" ]; then
   exit -1
 fi
 
+if [ ! -x "$(command -v node)" ]; then
+  echo "Node binary not found, please ensure it's properly setup"
+  exit -1
+fi
+
 ./node_modules/.bin/post-merge "$@"

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -7,7 +7,7 @@ if [ ! -d "$DIRECTORY" ]; then
 fi
 
 if [ ! -x "$(command -v node)" ]; then
-  echo "Node binary not found, please ensure it's properly setup"
+  echo "Node binary not found, please ensure it has been properly installed"
   exit -1
 fi
 

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -6,4 +6,9 @@ if [ ! -d "$DIRECTORY" ]; then
   exit -1
 fi
 
+if [ ! -x "$(command -v node)" ]; then
+  echo "Node binary not found, please ensure it's properly setup"
+  exit -1
+fi
+
 ./node_modules/.bin/pre-commit "$@"

--- a/hooks/pre-push
+++ b/hooks/pre-push
@@ -7,7 +7,7 @@ if [ ! -d "$DIRECTORY" ]; then
 fi
 
 if [ ! -x "$(command -v node)" ]; then
-  echo "Node binary not found, please ensure it's properly setup"
+  echo "Node binary not found, please ensure it has been properly installed"
   exit -1
 fi
 

--- a/hooks/pre-push
+++ b/hooks/pre-push
@@ -6,4 +6,9 @@ if [ ! -d "$DIRECTORY" ]; then
   exit -1
 fi
 
+if [ ! -x "$(command -v node)" ]; then
+  echo "Node binary not found, please ensure it's properly setup"
+  exit -1
+fi
+
 ./node_modules/.bin/pre-push "$@"


### PR DESCRIPTION
An odd case, yet there are some CI environments where they do checkout before env is initialized and there is no node therefore. That eliminates such class of errors