### PR TITLE
fix: when no package.json found, bail out instead of throwing

### DIFF
--- a/bin/commit-msg.js
+++ b/bin/commit-msg.js
@@ -11,7 +11,7 @@ const log = require('debug')('pre-git');
 function checkMessageAgainstPattern(msg, pattern) {
 
   var regex = new RegExp(pattern);
-  
+
   if (!regex.test(msg)) {
 
     var msgError = preGit.customMsgPatternError();
@@ -30,9 +30,12 @@ function checkMessageAgainstPattern(msg, pattern) {
 }
 
 function checkMessage(msg) {
-
+  if (preGit.noPackageJson()) {
+    console.warn("Project has no package.json, bailing out of git-pre hooks");
+    return;
+  }
   const msgPattern = preGit.customMsgPattern();
-  
+
   if (msgPattern) {
     checkMessageAgainstPattern(msg, msgPattern);
   }

--- a/bin/commit-msg.js
+++ b/bin/commit-msg.js
@@ -31,7 +31,7 @@ function checkMessageAgainstPattern(msg, pattern) {
 
 function checkMessage(msg) {
   if (preGit.noPackageJson()) {
-    console.warn("Project has no package.json, bailing out of git-pre hooks");
+    console.warn('Project has no package.json, bailing out of git-pre hooks');
     return;
   }
   const msgPattern = preGit.customMsgPattern();

--- a/src/pre-git.js
+++ b/src/pre-git.js
@@ -1,32 +1,32 @@
-"use strict";
+'use strict';
 
-const la = require("lazy-ass");
-const check = require("check-more-types");
-const ggit = require("ggit");
+const la = require('lazy-ass');
+const check = require('check-more-types');
+const ggit = require('ggit');
 
-var child = require("child_process");
-var path = require("path");
-var fs = require("fs");
+var child = require('child_process');
+var path = require('path');
+var fs = require('fs');
 
-const packageName = "pre-git";
-const log = require("debug")(packageName);
+const packageName = 'pre-git';
+const log = require('debug')(packageName);
 /* jshint -W079 */
-var Promise = require("bluebird");
+var Promise = require('bluebird');
 
-var label = "pre-commit:";
-// magic value, meaning we found package.json but it has no "config" object
-const MISSING_GIT_CONFIG = "MISSING_GIT_CONFIG";
+var label = 'pre-commit:';
+// magic value, meaning we found package.json but it has no 'config' object
+const MISSING_GIT_CONFIG = 'MISSING_GIT_CONFIG';
 
-var gitPrefix = process.env.GIT_PREFIX || "";
-log("git prefix env", process.env.GIT_PREFIX);
+var gitPrefix = process.env.GIT_PREFIX || '';
+log('git prefix env', process.env.GIT_PREFIX);
 
 function isAtRoot(dir) {
-  return dir === "/";
+  return dir === '/';
 }
 
 function isPackageAmongFiles(dir) {
   var files = fs.readdirSync(dir);
-  return files.indexOf("package.json") >= 0;
+  return files.indexOf('package.json') >= 0;
 }
 
 function hasPreGitInFile(packageFilename) {
@@ -41,14 +41,14 @@ function hasPreGitInFile(packageFilename) {
 }
 
 function verifyValidDirectory(dir) {
-  la(check.unemptyString(dir), "missing dir");
+  la(check.unemptyString(dir), 'missing dir');
 
   var cwd = process.cwd();
   if (isAtRoot(dir)) {
-    throw new Error("Could not find package.json starting from " + cwd);
-  } else if (!dir || dir === ".") {
+    throw new Error('Could not find package.json starting from ' + cwd);
+  } else if (!dir || dir === '.') {
     throw new Error(
-      "Cannot find package.json from unspecified directory via " + cwd
+      'Cannot find package.json from unspecified directory via ' + cwd
     );
   }
 }
@@ -58,19 +58,19 @@ function findPackage(dir) {
   var cwd = process.cwd();
   if (!dir) {
     dir = path.join(cwd, gitPrefix);
-    log("set dir to %s for cwd %s and git prefix %s", dir, cwd, gitPrefix);
+    log('set dir to %s for cwd %s and git prefix %s', dir, cwd, gitPrefix);
   }
 
   if (isPackageAmongFiles(dir)) {
-    const filename = path.join(dir, "package.json");
-    log("found package file %s", filename);
+    const filename = path.join(dir, 'package.json');
+    log('found package file %s', filename);
     if (hasConfigInFile(filename)) {
-      log("file %s has %s config", filename, packageName);
+      log('file %s has %s config', filename, packageName);
       return filename;
     }
     if (hasPreGitInFile(filename)) {
-      log("found pre-git dependency in %s", filename);
-      log("but no pre-git config");
+      log('found pre-git dependency in %s', filename);
+      log('but no pre-git config');
       return MISSING_GIT_CONFIG;
     }
   }
@@ -81,7 +81,7 @@ function findPackage(dir) {
   var parentPath = path.dirname(dir);
   if (parentPath === dir) {
     throw new Error(
-      "Cannot got up the folder to find package.json from " + cwd
+      'Cannot got up the folder to find package.json from ' + cwd
     );
   }
   return findPackage(parentPath);
@@ -89,7 +89,7 @@ function findPackage(dir) {
 
 function getPackage() {
   var filename = findPackage();
-  la(check.unemptyString(filename), "could not find package");
+  la(check.unemptyString(filename), 'could not find package');
   if (filename === MISSING_GIT_CONFIG) {
     return MISSING_GIT_CONFIG;
   }
@@ -102,7 +102,7 @@ function noPackageJson() {
     findPackage();
     return false;
   } catch (e) {
-    if ((e.message || "").indexOf("package.json") > 0) {
+    if ((e.message || '').indexOf('package.json') > 0) {
       return true;
     }
   }
@@ -112,17 +112,17 @@ function noPackageJson() {
 // Can we use ggit for this?
 function getProjRoot() {
   return new Promise(function(resolve, reject) {
-    child.exec("git rev-parse --show-toplevel", function onRoot(err, output) {
+    child.exec('git rev-parse --show-toplevel', function onRoot(err, output) {
       if (err) {
-        console.error("");
-        console.error(label, "Failed to find git root. Cannot run the tests.");
+        console.error('');
+        console.error(label, 'Failed to find git root. Cannot run the tests.');
         console.error(err);
-        console.error("");
-        return reject(new Error("Failed to find git in the project root"));
+        console.error('');
+        return reject(new Error('Failed to find git in the project root'));
       }
 
       var gitRoot = output.trim();
-      log("git root folder %s", gitRoot);
+      log('git root folder %s', gitRoot);
       var projRoot = gitRoot;
       var pkg;
       try {
@@ -130,27 +130,27 @@ function getProjRoot() {
         pkg = require(file);
         projRoot = path.dirname(file);
       } catch (e) {
-        log("could not find package in the git root folder");
+        log('could not find package in the git root folder');
         return resolve(gitRoot);
       }
 
       if (!hasConfig(pkg)) {
-        log("package in %s does not have config", projRoot);
+        log('package in %s does not have config', projRoot);
         const rootPackageFile = findPackage(gitRoot);
         if (rootPackageFile) {
           const rootPackage = require(rootPackageFile);
           if (hasConfig(rootPackage)) {
             projRoot = path.dirname(rootPackageFile);
-            log("found %s config in git root folder %s", packageName, projRoot);
+            log('found %s config in git root folder %s', packageName, projRoot);
             return resolve(projRoot);
           }
         } else {
-          log("missing config and root package file");
+          log('missing config and root package file');
         }
       }
 
-      if (pkg["pre-git-cwd"]) {
-        projRoot = path.resolve(path.join(gitRoot, pkg["pre-git-cwd"]));
+      if (pkg['pre-git-cwd']) {
+        projRoot = path.resolve(path.join(gitRoot, pkg['pre-git-cwd']));
       }
       return resolve(projRoot);
     });
@@ -164,44 +164,44 @@ function getProjRoot() {
  * @api private
  */
 function failure(label, err) {
-  console.error("");
-  console.error(label, "You've failed to pass all the hooks.");
+  console.error('');
+  console.error(label, 'You\'ve failed to pass all the hooks.');
   console.error(label);
 
-  const chalk = require("chalk");
+  const chalk = require('chalk');
   if (err instanceof Error) {
-    console.error(label, "An Error was thrown from command");
+    console.error(label, 'An Error was thrown from command');
     if (err.ran) {
       console.error(chalk.supportsColor ? chalk.bold.yellow(err.ran) : err.ran);
     }
 
-    const stack = err.stack.split("\n");
+    const stack = err.stack.split('\n');
     const firstLine = stack.shift();
     console.error(chalk.supportsColor ? chalk.red(firstLine) : firstLine);
     console.error(label);
     stack.forEach(function trace(line) {
-      console.error(label, "   " + line.trim());
+      console.error(label, '   ' + line.trim());
     });
   } else {
     console.error(label, chalk.supportsColor ? chalk.red(err) : err);
   }
 
-  const skipOption = label === "pre-push" ? "--no-verify" : "-n (--no-verify)";
+  const skipOption = label === 'pre-push' ? '--no-verify' : '-n (--no-verify)';
   const skipOptionText = chalk.supportsColor
     ? chalk.bold(skipOption)
     : skipOption;
   console.error(label);
   console.error(
     label,
-    "You can skip the git hook by running with",
+    'You can skip the git hook by running with',
     skipOptionText
   );
   console.error(label);
   console.error(
     label,
-    "But this is not advised as your tests are obviously failing."
+    'But this is not advised as your tests are obviously failing.'
   );
-  console.error("");
+  console.error('');
 
   process.exit(1);
 }
@@ -238,18 +238,18 @@ function getConfigProperty(propertyName) {
 }
 
 function hasEnabledOption(config) {
-  return "enabled" in config;
+  return 'enabled' in config;
 }
 
 function getTasks(label) {
-  log('getting tasks with label "%s"', label);
+  log('getting tasks with label \'%s\'', label);
   const config = getConfig();
   if (!config) {
     return;
   }
 
   var pkg = getPackage();
-  la(check.object(pkg), "missing package", pkg);
+  la(check.object(pkg), 'missing package', pkg);
 
   if (hasEnabledOption(config) && !config.enabled) {
     return;
@@ -260,7 +260,7 @@ function getTasks(label) {
   if (check.string(run)) {
     run = [run];
   }
-  log('tasks for label "%s" are', label, run);
+  log('tasks for label \'%s\' are', label, run);
   return run;
 }
 
@@ -271,7 +271,7 @@ function hasUntrackedFiles() {
       if (!config) {
         return resolve(false);
       }
-      if (config["allow-untracked-files"]) {
+      if (config['allow-untracked-files']) {
         return resolve(false);
       }
     } catch (err) {
@@ -285,42 +285,42 @@ function hasUntrackedFiles() {
 }
 
 function runTask(root, task) {
-  console.log('executing task "' + task + '"');
+  console.log('executing task ' + task);
 
   const options = {
     cwd: root,
     env: process.env,
-    stdio: "inherit"
+    stdio: 'inherit'
   };
 
   return new Promise(function(resolve, reject) {
     const proc = child.exec(task, options);
-    proc.stdout.on("data", process.stdout.write.bind(process.stdout));
-    proc.stderr.on("data", process.stderr.write.bind(process.stderr));
-    proc.on("close", function onTaskFinished(code) {
+    proc.stdout.on('data', process.stdout.write.bind(process.stdout));
+    proc.stderr.on('data', process.stderr.write.bind(process.stderr));
+    proc.on('close', function onTaskFinished(code) {
       if (code > 0) {
-        let err = new Error(task + " closed with code " + code);
+        let err = new Error(task + ' closed with code ' + code);
         err.ran = task;
         return reject(err);
       }
-      return resolve('task "' + task + '" passed');
+      return resolve('task ' + task + ' passed');
     });
   });
 }
 
 function checkInputs(label) {
-  if (typeof label !== "string" || !label) {
-    throw new Error("Expected string label (pre-commit, pre-push)");
+  if (typeof label !== 'string' || !label) {
+    throw new Error('Expected string label (pre-commit, pre-push)');
   }
 }
 
 function skipPrecommit() {
-  return process.argv[2] !== "origin";
+  return process.argv[2] !== 'origin';
 }
 
 function getSkipTest(label) {
   const skipConditions = {
-    "pre-push": skipPrecommit
+    'pre-push': skipPrecommit
   };
   function dontSkip() {
     return false;
@@ -331,48 +331,48 @@ function getSkipTest(label) {
 
 // returns a promise
 function runAtRoot(root, label) {
-  log("running %s at root %s", label, root);
-  log("cli arguments", process.argv);
-  la(check.unemptyString(label), "missing label", label);
+  log('running %s at root %s', label, root);
+  log('cli arguments', process.argv);
+  la(check.unemptyString(label), 'missing label', label);
   const skip = getSkipTest(label);
   if (skip()) {
-    log("skipping tasks for", label);
+    log('skipping tasks for', label);
     return Promise.resolve();
   }
 
   function showError(message) {
-    console.error("");
+    console.error('');
     console.error(label, message);
-    console.error("");
+    console.error('');
     return Promise.reject(new Error(message));
   }
 
   function noUntrackedFiles(foundUntrackedFiles) {
     if (foundUntrackedFiles) {
-      return showError("Cannot commit with untracked files present.");
+      return showError('Cannot commit with untracked files present.');
     }
   }
 
   if (!root) {
-    return showError("Failed to find git root. Cannot run the tests.");
+    return showError('Failed to find git root. Cannot run the tests.');
   }
 
   function runTasksForLabel() {
     if (noPackageJson()) {
       console.warn(
-        "No package.json found for repository. Bailing out of pre-git hooks."
+        'No package.json found for repository. Bailing out of pre-git hooks.'
       );
       return Promise.resolve();
     }
 
     var tasks = getTasks(label);
-    log("tasks for %s", label, tasks);
+    log('tasks for %s', label, tasks);
 
     if (!tasks || !tasks.length) {
-      console.log("");
-      console.log(label, "Nothing the hook needs to do. Bailing out.");
-      console.log("");
-      return Promise.resolve("Nothing to do for " + label);
+      console.log('');
+      console.log(label, 'Nothing the hook needs to do. Bailing out.');
+      console.log('');
+      return Promise.resolve('Nothing to do for ' + label);
     }
 
     const runTaskAt = runTask.bind(null, root);
@@ -380,12 +380,12 @@ function runAtRoot(root, label) {
   }
 
   if (root !== process.cwd()) {
-    log("switching current folder from %s to %s", process.cwd(), root);
+    log('switching current folder from %s to %s', process.cwd(), root);
   } else {
-    log("cwd %s", process.cwd());
+    log('cwd %s', process.cwd());
   }
 
-  if (label === "pre-commit") {
+  if (label === 'pre-commit') {
     return hasUntrackedFiles()
       .then(noUntrackedFiles)
       .then(runTasksForLabel);
@@ -395,14 +395,14 @@ function runAtRoot(root, label) {
 }
 
 function run(hookLabel) {
-  log("running", hookLabel);
+  log('running', hookLabel);
   checkInputs(hookLabel);
 
   label = hookLabel;
 
   // TODO should the failure action be outside?
   return getProjRoot()
-    .tap(root => log("running", hookLabel, "in", root))
+    .tap(root => log('running', hookLabel, 'in', root))
     .then(root => runAtRoot(root, hookLabel))
     .catch(err => failure(hookLabel, err));
 }
@@ -412,57 +412,57 @@ function errorMessage(err) {
 }
 
 function printError(x) {
-  console.error(errorMessage(x) || "Unknown error");
+  console.error(errorMessage(x) || 'Unknown error');
 }
 
 function isBuiltInWizardName(name) {
-  la(check.unemptyString(name), "invalid name", name);
+  la(check.unemptyString(name), 'invalid name', name);
   const builtIn = {
     simple: true,
     conventional: true,
-    "cz-conventional-changelog": true
+    'cz-conventional-changelog': true
   };
   return builtIn[name];
 }
 
 function loadWizard(name) {
-  la(check.unemptyString(name), "missing commit wizard name", name);
+  la(check.unemptyString(name), 'missing commit wizard name', name);
   const moduleNames = {
-    simple: "simple-commit-message",
-    conventional: "conventional-commit-message",
-    "cz-conventional-changelog": "conventional-commit-message"
+    simple: 'simple-commit-message',
+    conventional: 'conventional-commit-message',
+    'cz-conventional-changelog': 'conventional-commit-message'
   };
   const loadName = moduleNames[name];
-  la(check.unemptyString(loadName), "Unknown commit message wizard name", name);
-  log("loading wizard", loadName, "for name", name);
+  la(check.unemptyString(loadName), 'Unknown commit message wizard name', name);
+  log('loading wizard', loadName, 'for name', name);
   return require(loadName);
 }
 
 function getWizardName() {
   const config = getConfig();
-  const defaultName = "simple";
-  log("commit message wizard name from", config);
+  const defaultName = 'simple';
+  log('commit message wizard name from', config);
   if (!config) {
-    log("no config, using default name", defaultName);
+    log('no config, using default name', defaultName);
     return defaultName;
   }
   if (config.wizard) {
     la(
       check.unemptyString(config.wizard),
-      "expected wizard name",
+      'expected wizard name',
       config.wizard
     );
-    log("using wizard name", config.wizard);
+    log('using wizard name', config.wizard);
     return config.wizard;
   }
 
-  const value = config["commit-msg"];
+  const value = config['commit-msg'];
   if (check.unemptyString(value)) {
-    log("using config commit-msg property", value);
+    log('using config commit-msg property', value);
     return value;
   }
   if (check.array(value) && value.length === 1) {
-    log("using config commit-msg single value", value);
+    log('using config commit-msg single value', value);
     return value[0];
   }
 }
@@ -470,24 +470,24 @@ function getWizardName() {
 function pickWizard() {
   const wizardName = getWizardName();
   if (!wizardName) {
-    log("no wizard name set");
+    log('no wizard name set');
     return;
   }
-  log("using commit message wizard %s", wizardName);
+  log('using commit message wizard %s', wizardName);
 
   const wiz = isBuiltInWizardName(wizardName)
     ? loadWizard(wizardName)
     : require(wizardName);
-  la(check.fn(wiz.prompter), "missing wizard prompter", wizardName, wiz);
+  la(check.fn(wiz.prompter), 'missing wizard prompter', wizardName, wiz);
   return wiz;
 }
 
 function customCommitMsgPattern() {
-  return getConfigProperty("msg-pattern");
+  return getConfigProperty('msg-pattern');
 }
 
 function customCommitMsgPatternError() {
-  return getConfigProperty("msg-pattern-error");
+  return getConfigProperty('msg-pattern-error');
 }
 
 module.exports = {
@@ -503,7 +503,7 @@ module.exports = {
 };
 
 if (!module.parent) {
-  run("demo-error", () => true)
-    .then(() => log("finished all tasks"))
+  run('demo-error', () => true)
+    .then(() => log('finished all tasks'))
     .done();
 }

--- a/src/pre-git.js
+++ b/src/pre-git.js
@@ -1,35 +1,35 @@
-'use strict';
+"use strict";
 
-const la = require('lazy-ass');
-const check = require('check-more-types');
-const ggit = require('ggit');
+const la = require("lazy-ass");
+const check = require("check-more-types");
+const ggit = require("ggit");
 
-var child = require('child_process');
-var path = require('path');
-var fs = require('fs');
+var child = require("child_process");
+var path = require("path");
+var fs = require("fs");
 
-const packageName = 'pre-git';
-const log = require('debug')(packageName);
+const packageName = "pre-git";
+const log = require("debug")(packageName);
 /* jshint -W079 */
-var Promise = require('bluebird');
+var Promise = require("bluebird");
 
-var label = 'pre-commit:';
+var label = "pre-commit:";
 // magic value, meaning we found package.json but it has no "config" object
-const MISSING_GIT_CONFIG = 'MISSING_GIT_CONFIG';
+const MISSING_GIT_CONFIG = "MISSING_GIT_CONFIG";
 
-var gitPrefix = process.env.GIT_PREFIX || '';
-log('git prefix env', process.env.GIT_PREFIX);
+var gitPrefix = process.env.GIT_PREFIX || "";
+log("git prefix env", process.env.GIT_PREFIX);
 
 function isAtRoot(dir) {
-  return dir === '/';
+  return dir === "/";
 }
 
 function isPackageAmongFiles(dir) {
   var files = fs.readdirSync(dir);
-  return files.indexOf('package.json') >= 0;
+  return files.indexOf("package.json") >= 0;
 }
 
-function hasPreGitInFile (packageFilename) {
+function hasPreGitInFile(packageFilename) {
   var pkg = require(packageFilename);
   if (pkg.dependencies && pkg.dependencies[packageName]) {
     return true;
@@ -41,34 +41,36 @@ function hasPreGitInFile (packageFilename) {
 }
 
 function verifyValidDirectory(dir) {
-  la(check.unemptyString(dir), 'missing dir');
+  la(check.unemptyString(dir), "missing dir");
 
   var cwd = process.cwd();
   if (isAtRoot(dir)) {
-    throw new Error('Could not find package.json starting from ' + cwd);
-  } else if (!dir || dir === '.') {
-    throw new Error('Cannot find package.json from unspecified directory via ' + cwd);
+    throw new Error("Could not find package.json starting from " + cwd);
+  } else if (!dir || dir === ".") {
+    throw new Error(
+      "Cannot find package.json from unspecified directory via " + cwd
+    );
   }
 }
 
 // finds package.json with config by going up the folder chain
 function findPackage(dir) {
   var cwd = process.cwd();
-  if (! dir) {
+  if (!dir) {
     dir = path.join(cwd, gitPrefix);
-    log('set dir to %s for cwd %s and git prefix %s', dir, cwd, gitPrefix);
+    log("set dir to %s for cwd %s and git prefix %s", dir, cwd, gitPrefix);
   }
 
   if (isPackageAmongFiles(dir)) {
-    const filename = path.join(dir, 'package.json');
-    log('found package file %s', filename);
+    const filename = path.join(dir, "package.json");
+    log("found package file %s", filename);
     if (hasConfigInFile(filename)) {
-      log('file %s has %s config', filename, packageName);
+      log("file %s has %s config", filename, packageName);
       return filename;
     }
     if (hasPreGitInFile(filename)) {
-      log('found pre-git dependency in %s', filename);
-      log('but no pre-git config');
+      log("found pre-git dependency in %s", filename);
+      log("but no pre-git config");
       return MISSING_GIT_CONFIG;
     }
   }
@@ -78,14 +80,16 @@ function findPackage(dir) {
   // go to the parent folder and look there
   var parentPath = path.dirname(dir);
   if (parentPath === dir) {
-    throw new Error('Cannot got up the folder to find package.json from ' + cwd);
+    throw new Error(
+      "Cannot got up the folder to find package.json from " + cwd
+    );
   }
   return findPackage(parentPath);
 }
 
 function getPackage() {
   var filename = findPackage();
-  la(check.unemptyString(filename), 'could not find package');
+  la(check.unemptyString(filename), "could not find package");
   if (filename === MISSING_GIT_CONFIG) {
     return MISSING_GIT_CONFIG;
   }
@@ -93,50 +97,60 @@ function getPackage() {
   return pkg;
 }
 
+function noPackageJson() {
+  try {
+    findPackage();
+    return false;
+  } catch (e) {
+    if ((e.message || "").indexOf("package.json") > 0) {
+      return true;
+    }
+  }
+}
+
 // returns a promise
 // Can we use ggit for this?
 function getProjRoot() {
-  return new Promise(function (resolve, reject) {
-    child.exec('git rev-parse --show-toplevel', function onRoot(err, output) {
+  return new Promise(function(resolve, reject) {
+    child.exec("git rev-parse --show-toplevel", function onRoot(err, output) {
       if (err) {
-        console.error('');
-        console.error(label, 'Failed to find git root. Cannot run the tests.');
+        console.error("");
+        console.error(label, "Failed to find git root. Cannot run the tests.");
         console.error(err);
-        console.error('');
-        return reject(new Error('Failed to find git in the project root'));
+        console.error("");
+        return reject(new Error("Failed to find git in the project root"));
       }
 
       var gitRoot = output.trim();
-      log('git root folder %s', gitRoot);
+      log("git root folder %s", gitRoot);
       var projRoot = gitRoot;
       var pkg;
       try {
         var file = findPackage();
         pkg = require(file);
         projRoot = path.dirname(file);
-      }
-      catch (e) {
-        log('could not find package in the git root folder');
+      } catch (e) {
+        log("could not find package in the git root folder");
         return resolve(gitRoot);
       }
 
       if (!hasConfig(pkg)) {
-        log('package in %s does not have config', projRoot);
+        log("package in %s does not have config", projRoot);
         const rootPackageFile = findPackage(gitRoot);
         if (rootPackageFile) {
           const rootPackage = require(rootPackageFile);
           if (hasConfig(rootPackage)) {
             projRoot = path.dirname(rootPackageFile);
-            log('found %s config in git root folder %s', packageName, projRoot);
+            log("found %s config in git root folder %s", packageName, projRoot);
             return resolve(projRoot);
           }
         } else {
-          log('missing config and root package file');
+          log("missing config and root package file");
         }
       }
 
-      if (pkg['pre-git-cwd']) {
-        projRoot = path.resolve(path.join(gitRoot, pkg['pre-git-cwd']));
+      if (pkg["pre-git-cwd"]) {
+        projRoot = path.resolve(path.join(gitRoot, pkg["pre-git-cwd"]));
       }
       return resolve(projRoot);
     });
@@ -150,35 +164,44 @@ function getProjRoot() {
  * @api private
  */
 function failure(label, err) {
-  console.error('');
-  console.error(label, 'You\'ve failed to pass all the hooks.');
+  console.error("");
+  console.error(label, "You've failed to pass all the hooks.");
   console.error(label);
 
-  const chalk = require('chalk');
+  const chalk = require("chalk");
   if (err instanceof Error) {
-    console.error(label, 'An Error was thrown from command');
+    console.error(label, "An Error was thrown from command");
     if (err.ran) {
       console.error(chalk.supportsColor ? chalk.bold.yellow(err.ran) : err.ran);
     }
 
-    const stack = err.stack.split('\n');
+    const stack = err.stack.split("\n");
     const firstLine = stack.shift();
     console.error(chalk.supportsColor ? chalk.red(firstLine) : firstLine);
     console.error(label);
     stack.forEach(function trace(line) {
-      console.error(label, '   ' + line.trim());
+      console.error(label, "   " + line.trim());
     });
   } else {
     console.error(label, chalk.supportsColor ? chalk.red(err) : err);
   }
 
-  const skipOption = label === 'pre-push' ? '--no-verify' : '-n (--no-verify)';
-  const skipOptionText = chalk.supportsColor ? chalk.bold(skipOption) : skipOption;
+  const skipOption = label === "pre-push" ? "--no-verify" : "-n (--no-verify)";
+  const skipOptionText = chalk.supportsColor
+    ? chalk.bold(skipOption)
+    : skipOption;
   console.error(label);
-  console.error(label, 'You can skip the git hook by running with', skipOptionText);
+  console.error(
+    label,
+    "You can skip the git hook by running with",
+    skipOptionText
+  );
   console.error(label);
-  console.error(label, 'But this is not advised as your tests are obviously failing.');
-  console.error('');
+  console.error(
+    label,
+    "But this is not advised as your tests are obviously failing."
+  );
+  console.error("");
 
   process.exit(1);
 }
@@ -215,7 +238,7 @@ function getConfigProperty(propertyName) {
 }
 
 function hasEnabledOption(config) {
-  return 'enabled' in config;
+  return "enabled" in config;
 }
 
 function getTasks(label) {
@@ -226,15 +249,13 @@ function getTasks(label) {
   }
 
   var pkg = getPackage();
-  la(check.object(pkg), 'missing package', pkg);
+  la(check.object(pkg), "missing package", pkg);
 
   if (hasEnabledOption(config) && !config.enabled) {
     return;
   }
 
-  var run = pkg[label] ||
-    config &&
-    config[label];
+  var run = pkg[label] || (config && config[label]);
 
   if (check.string(run)) {
     run = [run];
@@ -244,22 +265,21 @@ function getTasks(label) {
 }
 
 function hasUntrackedFiles() {
-  return new Promise((resolve) => {
+  return new Promise(resolve => {
     try {
       const config = getConfig();
       if (!config) {
         return resolve(false);
       }
-      if(config['allow-untracked-files']) {
+      if (config["allow-untracked-files"]) {
         return resolve(false);
       }
     } catch (err) {
       return resolve(false);
     }
-    var p = ggit.untrackedFiles()
-      .then(function (names) {
-        return check.unempty(names);
-      });
+    var p = ggit.untrackedFiles().then(function(names) {
+      return check.unempty(names);
+    });
     resolve(p);
   });
 }
@@ -270,16 +290,16 @@ function runTask(root, task) {
   const options = {
     cwd: root,
     env: process.env,
-    stdio: 'inherit'
+    stdio: "inherit"
   };
 
-  return new Promise(function (resolve, reject) {
+  return new Promise(function(resolve, reject) {
     const proc = child.exec(task, options);
-    proc.stdout.on('data', process.stdout.write.bind(process.stdout));
-    proc.stderr.on('data', process.stderr.write.bind(process.stderr));
-    proc.on('close', function onTaskFinished(code) {
+    proc.stdout.on("data", process.stdout.write.bind(process.stdout));
+    proc.stderr.on("data", process.stderr.write.bind(process.stderr));
+    proc.on("close", function onTaskFinished(code) {
       if (code > 0) {
-        let err = new Error(task + ' closed with code ' + code);
+        let err = new Error(task + " closed with code " + code);
         err.ran = task;
         return reject(err);
       }
@@ -289,18 +309,18 @@ function runTask(root, task) {
 }
 
 function checkInputs(label) {
-  if (typeof label !== 'string' || !label) {
-    throw new Error('Expected string label (pre-commit, pre-push)');
+  if (typeof label !== "string" || !label) {
+    throw new Error("Expected string label (pre-commit, pre-push)");
   }
 }
 
 function skipPrecommit() {
-  return process.argv[2] !== 'origin';
+  return process.argv[2] !== "origin";
 }
 
 function getSkipTest(label) {
   const skipConditions = {
-    'pre-push': skipPrecommit
+    "pre-push": skipPrecommit
   };
   function dontSkip() {
     return false;
@@ -311,57 +331,48 @@ function getSkipTest(label) {
 
 // returns a promise
 function runAtRoot(root, label) {
-  log('running %s at root %s', label, root);
-  log('cli arguments', process.argv);
-  la(check.unemptyString(label), 'missing label', label);
+  log("running %s at root %s", label, root);
+  log("cli arguments", process.argv);
+  la(check.unemptyString(label), "missing label", label);
   const skip = getSkipTest(label);
   if (skip()) {
-    log('skipping tasks for', label);
+    log("skipping tasks for", label);
     return Promise.resolve();
   }
 
   function showError(message) {
-    console.error('');
+    console.error("");
     console.error(label, message);
-    console.error('');
+    console.error("");
     return Promise.reject(new Error(message));
   }
 
   function noUntrackedFiles(foundUntrackedFiles) {
     if (foundUntrackedFiles) {
-      return showError('Cannot commit with untracked files present.');
+      return showError("Cannot commit with untracked files present.");
     }
   }
 
   if (!root) {
-    return showError('Failed to find git root. Cannot run the tests.');
-  }
-
-  function noPackageJson() {
-    try {
-      findPackage();
-      return false;
-    } catch (e) {
-      if ((e.message || "").indexOf("package.json") > 0) {
-        return true;
-      }
-    }
+    return showError("Failed to find git root. Cannot run the tests.");
   }
 
   function runTasksForLabel() {
     if (noPackageJson()) {
-      console.warn("No package.json found for repository. Bailing out of pre-git hooks.");
+      console.warn(
+        "No package.json found for repository. Bailing out of pre-git hooks."
+      );
       return Promise.resolve();
     }
 
     var tasks = getTasks(label);
-    log('tasks for %s', label, tasks);
+    log("tasks for %s", label, tasks);
 
     if (!tasks || !tasks.length) {
-      console.log('');
-      console.log(label, 'Nothing the hook needs to do. Bailing out.');
-      console.log('');
-      return Promise.resolve('Nothing to do for ' + label);
+      console.log("");
+      console.log(label, "Nothing the hook needs to do. Bailing out.");
+      console.log("");
+      return Promise.resolve("Nothing to do for " + label);
     }
 
     const runTaskAt = runTask.bind(null, root);
@@ -369,13 +380,12 @@ function runAtRoot(root, label) {
   }
 
   if (root !== process.cwd()) {
-    log('switching current folder from %s to %s',
-      process.cwd(), root);
+    log("switching current folder from %s to %s", process.cwd(), root);
   } else {
-    log('cwd %s', process.cwd());
+    log("cwd %s", process.cwd());
   }
 
-  if (label === 'pre-commit') {
+  if (label === "pre-commit") {
     return hasUntrackedFiles()
       .then(noUntrackedFiles)
       .then(runTasksForLabel);
@@ -385,16 +395,16 @@ function runAtRoot(root, label) {
 }
 
 function run(hookLabel) {
-  log('running', hookLabel);
+  log("running", hookLabel);
   checkInputs(hookLabel);
 
   label = hookLabel;
 
   // TODO should the failure action be outside?
   return getProjRoot()
-    .tap((root) => log('running', hookLabel, 'in', root))
-    .then((root) => runAtRoot(root, hookLabel))
-    .catch((err) => failure(hookLabel, err));
+    .tap(root => log("running", hookLabel, "in", root))
+    .then(root => runAtRoot(root, hookLabel))
+    .catch(err => failure(hookLabel, err));
 }
 
 function errorMessage(err) {
@@ -402,54 +412,57 @@ function errorMessage(err) {
 }
 
 function printError(x) {
-  console.error(errorMessage(x) || 'Unknown error');
+  console.error(errorMessage(x) || "Unknown error");
 }
 
 function isBuiltInWizardName(name) {
-  la(check.unemptyString(name), 'invalid name', name);
+  la(check.unemptyString(name), "invalid name", name);
   const builtIn = {
     simple: true,
     conventional: true,
-    'cz-conventional-changelog': true
+    "cz-conventional-changelog": true
   };
   return builtIn[name];
 }
 
 function loadWizard(name) {
-  la(check.unemptyString(name), 'missing commit wizard name', name);
+  la(check.unemptyString(name), "missing commit wizard name", name);
   const moduleNames = {
-    simple: 'simple-commit-message',
-    conventional: 'conventional-commit-message',
-    'cz-conventional-changelog': 'conventional-commit-message'
+    simple: "simple-commit-message",
+    conventional: "conventional-commit-message",
+    "cz-conventional-changelog": "conventional-commit-message"
   };
   const loadName = moduleNames[name];
-  la(check.unemptyString(loadName),
-    'Unknown commit message wizard name', name);
-  log('loading wizard', loadName, 'for name', name);
+  la(check.unemptyString(loadName), "Unknown commit message wizard name", name);
+  log("loading wizard", loadName, "for name", name);
   return require(loadName);
 }
 
 function getWizardName() {
   const config = getConfig();
-  const defaultName = 'simple';
-  log('commit message wizard name from', config);
+  const defaultName = "simple";
+  log("commit message wizard name from", config);
   if (!config) {
-    log('no config, using default name', defaultName);
+    log("no config, using default name", defaultName);
     return defaultName;
   }
   if (config.wizard) {
-    la(check.unemptyString(config.wizard), 'expected wizard name', config.wizard);
-    log('using wizard name', config.wizard);
+    la(
+      check.unemptyString(config.wizard),
+      "expected wizard name",
+      config.wizard
+    );
+    log("using wizard name", config.wizard);
     return config.wizard;
   }
 
-  const value = config['commit-msg'];
+  const value = config["commit-msg"];
   if (check.unemptyString(value)) {
-    log('using config commit-msg property', value);
+    log("using config commit-msg property", value);
     return value;
   }
   if (check.array(value) && value.length === 1) {
-    log('using config commit-msg single value', value);
+    log("using config commit-msg single value", value);
     return value[0];
   }
 }
@@ -457,24 +470,24 @@ function getWizardName() {
 function pickWizard() {
   const wizardName = getWizardName();
   if (!wizardName) {
-    log('no wizard name set');
+    log("no wizard name set");
     return;
   }
-  log('using commit message wizard %s', wizardName);
+  log("using commit message wizard %s", wizardName);
 
-  const wiz = isBuiltInWizardName(wizardName) ?
-    loadWizard(wizardName) : require(wizardName);
-  la(check.fn(wiz.prompter), 'missing wizard prompter', wizardName, wiz);
+  const wiz = isBuiltInWizardName(wizardName)
+    ? loadWizard(wizardName)
+    : require(wizardName);
+  la(check.fn(wiz.prompter), "missing wizard prompter", wizardName, wiz);
   return wiz;
 }
 
 function customCommitMsgPattern() {
-  return getConfigProperty('msg-pattern');
-
+  return getConfigProperty("msg-pattern");
 }
 
 function customCommitMsgPatternError() {
-  return getConfigProperty('msg-pattern-error');
+  return getConfigProperty("msg-pattern-error");
 }
 
 module.exports = {
@@ -485,11 +498,12 @@ module.exports = {
   wizard: pickWizard,
   hasUntrackedFiles: hasUntrackedFiles,
   customMsgPattern: customCommitMsgPattern,
-  customMsgPatternError: customCommitMsgPatternError
+  customMsgPatternError: customCommitMsgPatternError,
+  noPackageJson: noPackageJson
 };
 
 if (!module.parent) {
-  run('demo-error', () => true)
-    .then(() => log('finished all tasks'))
+  run("demo-error", () => true)
+    .then(() => log("finished all tasks"))
     .done();
 }

--- a/src/pre-git.js
+++ b/src/pre-git.js
@@ -187,9 +187,7 @@ function failure(label, err) {
   }
 
   const skipOption = label === 'pre-push' ? '--no-verify' : '-n (--no-verify)';
-  const skipOptionText = chalk.supportsColor
-    ? chalk.bold(skipOption)
-    : skipOption;
+  const skipOptionText = chalk.supportsColor ? chalk.bold(skipOption) : skipOption;
   console.error(label);
   console.error(
     label,
@@ -475,9 +473,7 @@ function pickWizard() {
   }
   log('using commit message wizard %s', wizardName);
 
-  const wiz = isBuiltInWizardName(wizardName)
-    ? loadWizard(wizardName)
-    : require(wizardName);
+  const wiz = isBuiltInWizardName(wizardName) ? loadWizard(wizardName) : require(wizardName);
   la(check.fn(wiz.prompter), 'missing wizard prompter', wizardName, wiz);
   return wiz;
 }

--- a/src/pre-git.js
+++ b/src/pre-git.js
@@ -337,7 +337,23 @@ function runAtRoot(root, label) {
     return showError('Failed to find git root. Cannot run the tests.');
   }
 
+  function noPackageJson() {
+    try {
+      findPackage();
+      return false;
+    } catch (e) {
+      if ((e.message || "").indexOf("package.json") > 0) {
+        return true;
+      }
+    }
+  }
+
   function runTasksForLabel() {
+    if (noPackageJson()) {
+      console.warn("No package.json found for repository. Bailing out of pre-git hooks.");
+      return Promise.resolve();
+    }
+
     var tasks = getTasks(label);
     log('tasks for %s', label, tasks);
 


### PR DESCRIPTION
When installing `pre-git` into a pre-existing git repository, when the team works with a feature-branch strategy like git-flow or similar, switching between branches which have a `package.json` and branches which do not (yet) fails because the incoming branch has not had `package.json` merged in. Hooks are fired irrespective of branch, so this patch is simply to log a warning when unable to find `package.json` so that the checkout can complete successfully.

I've just had several instances of this -- it's a problem which will eventually go away, but, in the meantime, or for any other project busy with integrating `pre-git`, a missing `package.json` should rather result in a warning than a broken checkout which leaves the client repo in a detached state.